### PR TITLE
Changes the way memoization works so that user Promise implementation…

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -101,11 +101,12 @@ describe('reusePromise', function () {
     assert.notEqual(p1, test.find(1))
   })
 
-  it('keeps the previous value if {memoize: true} even after promise resolved', async function () {
-    const p1value = await test.findAndMemoize(1)
-    const p2value = await test.findAndMemoize(1)
+  it('keeps the previous promise if {memoize: true} even after promise resolved', async function () {
+    const p1 = test.findAndMemoize(1)
+    await p1
+    const p2 = test.findAndMemoize(1)
 
-    assert.equal(p1value, p2value)
+    assert.equal(p1, p2)
   })
 
   it('fullfils the promise once with same value', function (done) {


### PR DESCRIPTION
…s aren't replaced

Instead of keeping track of memoized results separately, memoized results simply aren't removed from the pending promise map when they resolve.

Currently, when memoizing, promise resolution values are cached, and then a `Promise.resolve(<resolution value>)` is returned later when a cached value is retrieved. This causes problems when using a Promise implementation other than node's default.

For example:

```
Promise = require('bluebird');
reusePromise = require('reuse-promise').default;

function getList() {
    return Promise.resolve([1, 2, 3]);
}

reuseGetList = reusePromise(getList, { memoize: true })

reuseGetList().map(console.log)  // fine, since bluebird promise is returned
reuseGetList().map(console.log)  // error, since a node Promise, without map method is returned
```

I'm not sure I got everything right, or if you agree with this way of doing it, but let me know what you think.
